### PR TITLE
Add evidence classification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -91,6 +91,9 @@ components:
         type: string
       truncated:
         type: boolean
+      category:
+        type: string
+        description: "Classification of the document ('case facts' or 'country conditions')"
       summary:
         type: string
       keyFacts:

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1,0 +1,28 @@
+import io
+from fastapi.testclient import TestClient
+from main import app
+from auth import LAWQB_API_KEY
+
+client = TestClient(app)
+
+def test_case_facts_txt():
+    content = b"This affidavit describes events in detail."
+    files = {"file": ("facts.txt", content, "text/plain")}
+    data = {"jurisdiction": "EOIR"}
+    headers = {"x-api-key": LAWQB_API_KEY}
+    resp = client.post("/uploadEvidence", files=files, data=data, headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["category"] == "case facts"
+
+
+def test_country_conditions_txt():
+    content = b"According to the U.S. Department of State Country Report, conditions remain unstable."
+    files = {"file": ("cc.txt", content, "text/plain")}
+    data = {"jurisdiction": "EOIR"}
+    headers = {"x-api-key": LAWQB_API_KEY}
+    resp = client.post("/uploadEvidence", files=files, data=data, headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["category"] == "country conditions"
+

--- a/tests/test_upload_pdf.py
+++ b/tests/test_upload_pdf.py
@@ -24,4 +24,5 @@ def test_pdf_upload():
     assert resp.status_code == 200
     body = resp.json()
     assert body["fileType"] == "pdf"
+    assert body["category"] == "case facts"
 


### PR DESCRIPTION
## Summary
- add `classify_text` helper and reuse in `utils/simple_split.py`
- include classification in `SummarizeEvidenceResponse`
- handle optional docx and pdf support
- document new `category` field in OpenAPI spec
- test classification of uploads

## Testing
- `pytest -q` *(fails: command not found)*